### PR TITLE
Fix byte count for AXP192 coulomb counter readings

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -136,7 +136,7 @@ uint32_t AXP192::Read32bit(uint8_t Addr)
     Wire1.beginTransmission(0x34);
     Wire1.write(Addr);
     Wire1.endTransmission();
-    Wire1.requestFrom(0x34, 2);
+    Wire1.requestFrom(0x34, 4);
     for (int i = 0; i < 4; i++)
     {
         ReData <<= 8;
@@ -224,7 +224,7 @@ float AXP192::GetCoulombData(void)
 
     //c = 65536 * current_LSB * (coin - coout) / 3600 / ADC rate
     //Adc rate can be read from 84H ,change this variable if you change the ADC reate
-    float ccc = 65536 * 0.5 * (coin - coout) / 3600.0 / 25.0;
+    float ccc = 65536 * 0.5 * (int32_t)(coin - coout) / 3600.0 / 25.0;
     return ccc;
 }
 


### PR DESCRIPTION
In this conjunktion also M5.Axp.GetCoulombData() for negative counter differences is fixed.
