### PR TITLE
Add flag to toggle offscreen text drawing

### DIFF
--- a/src/utility/In_eSPI.cpp
+++ b/src/utility/In_eSPI.cpp
@@ -4726,11 +4726,13 @@ int16_t TFT_eSPI::drawString(const char *string, int32_t poX, int32_t poY, uint8
         padding += 2;
         break;
     }
+    #ifdef FORCE_TEXT_ON_SCREEN
     // Check coordinates are OK, adjust if not
     if (poX < 0) poX = 0;
     if (poX+cwidth > width())   poX = width() - cwidth;
     if (poY < 0) poY = 0;
     if (poY+cheight-baseline> height()) poY = height() - cheight;
+    #endif
   }
 
 


### PR DESCRIPTION
This allows you to draw text such that characters that would be drawn cannot be seen since they are offscreen (say, -100)  
The functionality is toggled on with `#define FORCE_TEXT_ON_SCREEN`