### PR TITLE
Fix DCDC2 voltage settings and improve voltage calculation

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -389,13 +389,11 @@ bool AXP192::isACIN() { return (Read8bit(0x00) & 0x80) ? true : false; }
 bool AXP192::isCharging() { return (Read8bit(0x00) & 0x04) ? true : false; }
 bool AXP192::isVBUS() { return (Read8bit(0x00) & 0x20) ? true : false; }
 
-uint8_t calcVoltageData(uint16_t value, uint16_t maxv, uint16_t minv, uint16_t step)
-{
+uint8_t calcVoltageData(uint16_t value, uint16_t maxv, uint16_t minv,
+                        uint16_t step) {
   uint8_t data = 0;
-  if (value > maxv)
-      value = maxv;
-  if (value > minv)
-      data = (value - minv) / step;
+  if (value > maxv) value = maxv;
+  if (value > minv) data = (value - minv) / step;
   return data;
 }
 

--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -410,18 +410,21 @@ void AXP192::SetDCVoltage(uint8_t number, uint16_t voltage) {
   switch (number) {
     case 0:
       addr = 0x26;
+      voltage &= 0x7F;
       break;
     case 1:
-      addr = 0x23;
+      addr = 0x25;
+      voltage &= 0x3F;
       break;
     case 2:
       addr = 0x27;
+      voltage &= 0x7F;
       break;
   }
   // Serial.printf("result:%hhu\n", (Read8bit(addr) & 0X80) | (voltage & 0X7F));
   // Serial.printf("result:%d\n", (Read8bit(addr) & 0X80) | (voltage & 0X7F));
   // Serial.printf("result:%x\n", (Read8bit(addr) & 0X80) | (voltage & 0X7F));
-  Write1Byte(addr, (Read8bit(addr) & 0X80) | (voltage & 0X7F));
+  Write1Byte(addr, (Read8bit(addr) & 0x80) | voltage));
 }
 
 void AXP192::SetESPVoltage(uint16_t voltage) {


### PR DESCRIPTION
To set the voltage of DCDC2 register 23H needs to be used, not 25H (see https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/AXP192_datasheet_cn.pdf). This PR will fix #82.

Also DCDC2 only has a range of 700mV to 2275 mV (6Bits). To prevent miss calculations for an out range value I added a helper method, that is used for LDO and DCDC voltage settings calculations.