### PR TITLE
[workflow] fix LibraryBuild.yml

### DIFF
--- a/.github/workflows/LibraryBuild.yml
+++ b/.github/workflows/LibraryBuild.yml
@@ -29,4 +29,5 @@ jobs:
         arduino-board-fqbn:  esp32:esp32:m5stack-core2
         platform-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
         sketch-names-find-start: examples/Basics/
+        extra-arduino-cli-args: "--warnings default "
         sketches-exclude: mpu6886


### PR DESCRIPTION
fix for `cc1: warnings being treated as errors`

Please note the errors will go away in the workflow, but some examples and parts of the library will still need to be fixed.

As a maintainer you should set this option in your Arduino IDE during local development:

![image](https://user-images.githubusercontent.com/1893754/180962149-cbe0d018-38ed-4b90-8aa2-2c6d9192ae17.png)


