### PR TITLE
use std::function callbacks for Button and Gesture events

### DIFF
--- a/src/utility/M5Button.cpp
+++ b/src/utility/M5Button.cpp
@@ -254,11 +254,11 @@ bool Button::releasedFor(uint32_t ms) {
 
 uint32_t Button::lastChange() { return (_lastChange); }
 
-void Button::addHandler(void (*fn)(Event&), uint16_t eventMask /* = E_ALL */) {
+void Button::addHandler(EventHandlerCallback fn, uint16_t eventMask /* = E_ALL */) {
   BUTTONS->addHandler(fn, eventMask, this, nullptr);
 }
 
-void Button::delHandlers(void (*fn)(Event&) /* = nullptr */) {
+void Button::delHandlers(EventHandlerCallback fn /* = nullptr */) {
   BUTTONS->delHandlers(fn, this, nullptr);
 }
 
@@ -511,7 +511,7 @@ void M5Buttons::fireEvent(uint8_t finger, uint16_t type, Point& from, Point& to,
   }
 }
 
-void M5Buttons::addHandler(void (*fn)(Event&), uint16_t eventMask /* = E_ALL */,
+void M5Buttons::addHandler(EventHandlerCallback fn, uint16_t eventMask /* = E_ALL */,
                            Button* button /* = nullptr */,
                            Gesture* gesture /* = nullptr */
 ) {
@@ -523,7 +523,7 @@ void M5Buttons::addHandler(void (*fn)(Event&), uint16_t eventMask /* = E_ALL */,
   _eventHandlers.push_back(handler);
 }
 
-void M5Buttons::delHandlers(void (*fn)(Event&) /* = nullptr */,
+void M5Buttons::delHandlers(EventHandlerCallback fn /* = nullptr */,
                             Button* button /* = nullptr */,
                             Gesture* gesture /* = nullptr */
 ) {
@@ -610,11 +610,11 @@ bool Gesture::test(Point& from, Point& to, uint16_t duration) {
 
 bool Gesture::wasDetected() { return _detected; }
 
-void Gesture::addHandler(void (*fn)(Event&), uint16_t eventMask /* = E_ALL */) {
+void Gesture::addHandler(EventHandlerCallback fn, uint16_t eventMask /* = E_ALL */) {
   BUTTONS->addHandler(fn, eventMask, nullptr, this);
 }
 
-void Gesture::delHandlers(void (*fn)(Event&) /* = nullptr */) {
+void Gesture::delHandlers(EventHandlerCallback fn /* = nullptr */) {
   BUTTONS->delHandlers(fn, nullptr, this);
 }
 

--- a/src/utility/M5Button.cpp
+++ b/src/utility/M5Button.cpp
@@ -528,7 +528,8 @@ void M5Buttons::delHandlers(EventHandlerCallback fn /* = nullptr */,
                             Gesture* gesture /* = nullptr */
 ) {
   for (int i = _eventHandlers.size() - 1; i >= 0; --i) {
-    if (fn && fn != _eventHandlers[i].fn) continue;
+    // this doesn't compile anymore
+    //if (fn && fn != _eventHandlers[i].fn) continue;
     if (button && _eventHandlers[i].button != button) continue;
     if (gesture && _eventHandlers[i].gesture != gesture) continue;
     _eventHandlers.erase(_eventHandlers.begin() + i);

--- a/src/utility/M5Button.h
+++ b/src/utility/M5Button.h
@@ -724,6 +724,7 @@
 class Gesture;
 
 #include <Arduino.h>
+#include <functional>
 #include <Free_Fonts.h>
 #include <M5Display.h>
 
@@ -801,6 +802,8 @@ class Event {
   Gesture* gesture;
 };
 
+typedef std::function<void(Event&)> EventHandlerCallback;
+
 class Button : public Zone {
  public:
   static std::vector<Button*> instances;
@@ -836,8 +839,8 @@ class Button : public Zone {
   bool pressedFor(uint32_t ms, uint32_t continuous_time);
   bool releasedFor(uint32_t ms);
   bool wasReleasefor(uint32_t ms);
-  void addHandler(void (*fn)(Event&), uint16_t eventMask = E_ALL);
-  void delHandlers(void (*fn)(Event&) = nullptr);
+  void addHandler(EventHandlerCallback fn, uint16_t eventMask = E_ALL);
+  void delHandlers(EventHandlerCallback fn = nullptr);
   char* getName();
   uint32_t lastChange();
   Event event;
@@ -903,8 +906,8 @@ class Gesture {
   int16_t instanceIndex();
   bool test(Point& from, Point& to, uint16_t duration);
   bool wasDetected();
-  void addHandler(void (*fn)(Event&), uint16_t eventMask = E_ALL);
-  void delHandlers(void (*fn)(Event&) = nullptr);
+  void addHandler(EventHandlerCallback fn, uint16_t eventMask = E_ALL);
+  void delHandlers(EventHandlerCallback fn = nullptr);
   char* getName();
   Zone fromZone;
   Zone toZone;
@@ -924,7 +927,7 @@ struct EventHandler {
   uint16_t eventMask;
   Button* button;
   Gesture* gesture;
-  void (*fn)(Event&);
+  EventHandlerCallback fn;
 };
 
 class M5Buttons {
@@ -941,9 +944,9 @@ class M5Buttons {
   void (*drawFn)(Button& b, ButtonColors bc);
   void fireEvent(uint8_t finger, uint16_t type, Point& from, Point& to,
                  uint16_t duration, Button* button, Gesture* gesture);
-  void addHandler(void (*fn)(Event&), uint16_t eventMask = E_ALL,
+  void addHandler(EventHandlerCallback fn, uint16_t eventMask = E_ALL,
                   Button* button = nullptr, Gesture* gesture = nullptr);
-  void delHandlers(void (*fn)(Event&), Button* button, Gesture* gesture);
+  void delHandlers(EventHandlerCallback fn, Button* button, Gesture* gesture);
   Event event;
 
  protected:


### PR DESCRIPTION
the original callback declarations offer limited usability in terms of instance methods and lambda expressions. furthermore, other parts of M5 lib already rely on functional lib so no new lib deps are added.

existing code is basically backwards compatible, however: delHandlers function won't work anymore if used with the (former) callback pointer. std::function instances cannot be compared concerning their underlying handler in a trivial way.