### PR TITLE
fix compile error in c++17

### DIFF
--- a/src/utility/quaternionFilters.cpp
+++ b/src/utility/quaternionFilters.cpp
@@ -32,7 +32,7 @@ static float GyroMeasError = PI * (40.0f / 180.0f);
 // the faster the solution converges, usually at the expense of accuracy.
 // In any case, this is the free parameter in the Madgwick filtering and
 // fusion scheme.
-static float beta = sqrt(3.0f / 4.0f) * GyroMeasError;  // Compute beta
+static float beta_ = sqrt(3.0f / 4.0f) * GyroMeasError;  // Compute beta
 // Compute zeta, the other free parameter in the Madgwick scheme usually
 // set to a small or zero value
 // static float zeta = sqrt(3.0f / 4.0f) * GyroMeasDrift;
@@ -149,10 +149,10 @@ void MadgwickQuaternionUpdate(float ax, float ay, float az, float gx, float gy,
   s4 *= norm;
 
   // Compute rate of change of quaternion
-  qDot1 = 0.5f * (-q2 * gx - q3 * gy - q4 * gz) - beta * s1;
-  qDot2 = 0.5f * (q1 * gx + q3 * gz - q4 * gy) - beta * s2;
-  qDot3 = 0.5f * (q1 * gy - q2 * gz + q4 * gx) - beta * s3;
-  qDot4 = 0.5f * (q1 * gz + q2 * gy - q3 * gx) - beta * s4;
+  qDot1 = 0.5f * (-q2 * gx - q3 * gy - q4 * gz) - beta_ * s1;
+  qDot2 = 0.5f * (q1 * gx + q3 * gz - q4 * gy) - beta_ * s2;
+  qDot3 = 0.5f * (q1 * gy - q2 * gz + q4 * gx) - beta_ * s3;
+  qDot4 = 0.5f * (q1 * gz + q2 * gy - q3 * gx) - beta_ * s4;
 
   // Integrate to yield quaternion
   q1 += qDot1 * deltat;


### PR DESCRIPTION
In c++17, the beta function is global.
Therefore, compiling with c++17 fails at quaternionFilters.cpp.