### PR TITLE
Fix for Core2 setBrightness

### DIFF
--- a/src/M5Display.cpp
+++ b/src/M5Display.cpp
@@ -37,7 +37,7 @@ void M5Display::wakeup() {
 }
 
 void M5Display::setBrightness(uint8_t brightness) {
-  ledcWrite(BLK_PWM_CHANNEL, brightness);
+  M5.Axp.SetLcdVoltage(map(bright,0,100,2500,3300));
 }
 
 void M5Display::drawBitmap(int16_t x0, int16_t y0, int16_t w, int16_t h,

--- a/src/M5Display.cpp
+++ b/src/M5Display.cpp
@@ -37,7 +37,9 @@ void M5Display::wakeup() {
 }
 
 void M5Display::setBrightness(uint8_t brightness) {
-  M5.Axp.SetLcdVoltage(map(bright,0,100,2500,3300));
+  if (brightness > 100) { brightness = 100; }
+  if (brightness < 0) { brightness = 0; }
+  M5.Axp.SetLcdVoltage(map(brightness,0,100,2500,3300));
 }
 
 void M5Display::drawBitmap(int16_t x0, int16_t y0, int16_t w, int16_t h,

--- a/src/M5Display.h
+++ b/src/M5Display.h
@@ -32,7 +32,7 @@ class M5Display : public TFT_eSPI {
   void begin();
   void sleep();
   void wakeup();
-  void setBrightness(uint8_t brightness);
+  void setBrightness(uint8_t brightness);   // 0 to 100
   void clearDisplay(uint32_t color = ILI9341_BLACK) { fillScreen(color); }
   void clear(uint32_t color = ILI9341_BLACK) { fillScreen(color); }
   void display() {}


### PR DESCRIPTION
No constraints of map function. Might want to add those if the AXP might generate out of spec voltages.