### PR TITLE
Fixed an issue where SSID and PASSWD were not printed correctly if they exceeded 14 characters.

### DIFF
--- a/examples/Advanced/WIFI/WiFiSetting/WiFiSetting.ino
+++ b/examples/Advanced/WIFI/WiFiSetting/WiFiSetting.ino
@@ -77,8 +77,8 @@ restoreConfig() { /* Check whether there is wifi configuration information
     wifi_password = preferences.getString("WIFI_PASSWD");
     M5.Lcd.printf(
         "WIFI-SSID: %s\n",
-        wifi_ssid);  // Screen print format string.  屏幕打印格式化字符串
-    M5.Lcd.printf("WIFI-PASSWD: %s\n", wifi_password);
+        wifi_ssid.c_str());  // Screen print format string.  屏幕打印格式化字符串
+    M5.Lcd.printf("WIFI-PASSWD: %s\n", wifi_password.c_str());
     WiFi.begin(wifi_ssid.c_str(), wifi_password.c_str());
 
     if (wifi_ssid.length() > 0) {
@@ -130,9 +130,9 @@ void startWebServer() {  // Open the web service.  打开Web服务
             });
         webServer.on("/setap", []() {
             String ssid = urlDecode(webServer.arg("ssid"));
-            M5.Lcd.printf("SSID: %s\n", ssid);
+            M5.Lcd.printf("SSID: %s\n", ssid.c_str());
             String pass = urlDecode(webServer.arg("pass"));
-            M5.Lcd.printf("Password: %s\n\nWriting SSID to EEPROM...\n", pass);
+            M5.Lcd.printf("Password: %s\n\nWriting SSID to EEPROM...\n", pass.c_str());
 
             // Store wifi config.  存储wifi配置信息
             M5.Lcd.println("Writing Password to nvr...");


### PR DESCRIPTION
SSID and PASSWD were printed correctly when they were under 13 characters, but they were not printed correctly when they exceeded 14 characters. Therefore, I fixed this problem with this commit.

Both `SSID` and `PASSWD` are 13 characters (`1234567890abc`).
<img width="250px" src="https://github.com/user-attachments/assets/37a73db8-0103-4ecd-b4e7-59c106b23197">
 
`SSID` is 13 characters (`1234567890abc`), and `PASSWD` is 14 characters (`1234567890abcd`).
<img width="250px" src="https://github.com/user-attachments/assets/f2a258e5-a49a-49ed-955a-416d8786fd42">

Both `SSID` and `PASSWD` are 14 characters (`1234567890abcd`).
<img width="250px" src="https://github.com/user-attachments/assets/9f1239ff-19b9-4238-b12e-03b5ea7c8c77">