### PR TITLE
fix ESP32 error: 'GPIO' was not declared in this scope

### DIFF
--- a/src/utility/In_eSPI.h
+++ b/src/utility/In_eSPI.h
@@ -19,6 +19,8 @@
 
 // #define ESP32 //Just used to test ESP32 options
 
+#include "hal/gpio_ll.h"
+
 // Include header file that defines the fonts loaded, the TFT drivers
 // available and the pins to be used
 #include "In_eSPI_Setup.h"


### PR DESCRIPTION
fix ESP32 error: 'GPIO' was not declared in this scope

Same exists for M5StickC:
https://github.com/f-hoepfinger-hr-agrartechnik/M5StickC/blob/75cec4dae9499c101c938cdff0a7dc28951a717c/src/utility/In_eSPI.h#L22